### PR TITLE
Report correct difficulty

### DIFF
--- a/src/rpcblockchain.cpp
+++ b/src/rpcblockchain.cpp
@@ -38,12 +38,12 @@ double GetDifficulty(const CBlockIndex* blockindex)
     double dDiff =
         (double)0x0000ffff / (double)(blockindex->nBits & 0x00ffffff);
 
-    while (nShift < 29)
+    while (nShift < 30)
     {
         dDiff *= 256.0;
         nShift++;
     }
-    while (nShift > 29)
+    while (nShift > 30)
     {
         dDiff /= 256.0;
         nShift--;


### PR DESCRIPTION
The same bug was reported to MUE team in the october last year.
Currently its impossible to properly calculate mining rewards against the difficulty, as the results are multiplied by 256.
I think that the bug comes from forking the code from Dash.

Link to commit that fixed it for MUE: https://github.com/MonetaryUnit/MUE-Src/commit/23639453cf443455e200864d77af60f3ceb5d280