### PR TITLE
[UI] Wallet User Editable Themes: (PoC)

### DIFF
--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -806,6 +806,11 @@ void restoreWindowGeometry(const QString& strSetting, const QSize& defaultSize, 
     parent->move(pos);
 }
 
+// Check whether a theme is not build-in
+bool isExternal(QString theme){
+    return (theme.operator !=("drk")) && (theme.operator !=("drk-1")) && (theme.operator !=("drkblue")) && (theme.operator !=("trad"));
+}
+
 // Open CSS when configured
 QString loadStyleSheet()
 {
@@ -814,19 +819,29 @@ QString loadStyleSheet()
     QString cssName;
     QString theme = settings.value("theme", "").toString();
 
-    if(!theme.isEmpty()){
-        cssName = QString(":/css/") + theme; 
+    if(isExternal(theme)){
+        // External CSS
+        settings.setValue("fCSSexternal", true);
+        boost::filesystem::path pathAddr = GetDataDir() / "themes/";
+        cssName = pathAddr.c_str() + theme + "/css/theme.css";
     }
-    else {
-        cssName = QString(":/css/drk-1");  
-        settings.setValue("theme", "drk-1");
+    else{
+        // Build-in CSS
+        settings.setValue("fCSSexternal", false);
+        if(!theme.isEmpty()){
+            cssName = QString(":/css/") + theme;
+        }
+        else {
+            cssName = QString(":/css/drk-1");  
+            settings.setValue("theme", "drk-1");
+        }
     }
-    
+
     QFile qFile(cssName);      
     if (qFile.open(QFile::ReadOnly)) {
         styleSheet = QLatin1String(qFile.readAll());
     }
-        
+
     return styleSheet;
 }
 

--- a/src/qt/guiutil.h
+++ b/src/qt/guiutil.h
@@ -182,7 +182,10 @@ namespace GUIUtil
 
     /** Load global CSS theme */
     QString loadStyleSheet();
-    
+
+    /** Check whether a theme is not build-in */
+    bool isExternal(QString theme);
+
     /* Convert QString to OS specific boost path through UTF-8 */
     boost::filesystem::path qstringToBoostPath(const QString &path);
 

--- a/src/qt/optionsdialog.cpp
+++ b/src/qt/optionsdialog.cpp
@@ -81,12 +81,22 @@ OptionsDialog::OptionsDialog(QWidget *parent, bool enableWallet) :
         ui->digits->addItem(digits, digits);
     }
     
-    /* Theme selector */
+    /* Theme selector static themes */
     ui->theme->addItem(QString("DNET-dark"), QVariant("drk"));
     ui->theme->addItem(QString("DNET-dark-1"), QVariant("drk-1"));
     ui->theme->addItem(QString("DNET-blue"), QVariant("drkblue"));
     ui->theme->addItem(QString("DNET-traditional"), QVariant("trad"));
 
+    /* Theme selector external themes */
+    boost::filesystem::path pathAddr = GetDataDir() / "themes";
+    QDir dir(pathAddr.c_str());
+    dir.setFilter(QDir::Dirs | QDir::NoSymLinks | QDir::NoDotAndDotDot);
+    QFileInfoList list = dir.entryInfoList();
+
+    for (int i = 0; i < list.size(); ++i){
+         QFileInfo fileInfo = list.at(i);
+         ui->theme->addItem(fileInfo.fileName(), QVariant(fileInfo.fileName()));
+    }
     
     /* Language selector */
     QDir translations(":translations");

--- a/src/qt/optionsmodel.cpp
+++ b/src/qt/optionsmodel.cpp
@@ -134,6 +134,8 @@ void OptionsModel::Init()
         settings.setValue("digits", "2");
     if (!settings.contains("theme"))
         settings.setValue("theme", "");
+    if (!settings.contains("fCSSexternal"))
+        settings.setValue("fCSSexternal", false);
     if (!settings.contains("language"))
         settings.setValue("language", "");
     if (!SoftSetArg("-lang", settings.value("language").toString().toStdString()))


### PR DESCRIPTION
This is a rough PoC of user editable wallet themes. It only provides the technical infrastructure to allow user definable themes. The themes itself must be edited by hand.

**How to add a new theme to the Darknet wallet:**
- locate your darknet-qt's data folder (usually '.darknet' in your users home folder) and create a new folder "themes" there.
- get a copy of Darknets source from https://github.com/Darknet-Crypto/Darknet. Just click on the "Clone or download" button.
- copy Darknets resource folder ('Darknet/src/qt/res') into the "themes" folder you have create above, so you  have a folder '.darknet/themes/res' now
- rename this folder from 'res' to the name of your theme, e.g. 'MySexyTheme'
- edit the theme to your liking. Colors, fonts, location/size/width of most UI-elements can be edited here. Some CSS knowledge is need for that. Images are located in the "images" folder, icons in the "icons" folder.
- when you start your wallet the next time, the options-dialog will offer a new theme named 'MySexyTheme' which you can select exactly like the other build-in themes. Select your new theme.
- after restart of the wallet the new theme will be used

**Things you need to know:**
- Qt-CSS always uses the path relative to the running Qt-program, so if you want to use different images for your new CSS you'd either have to use absolute paths (like /home/yourname/.darknet/themes/MySexyTheme/images/bg.png) or have to place darknet-qt into the '.darknet' folder and use relative paths to get them displayed. If you intend to give your theme to other users the latter is the way to go, together with the information that they have to move darknet-qt to the data folder. Another way to accomplish this is to use links to images located some where in the web, you'd just have to use the URL instead. e.g. https://dl.dropboxusercontent.com/s/arythh4c3zyw497/01.png
- some screen elements like the splash-screen during start cannot be changed.

Please test, and if you have some spare time write a more detailed HowTo to allow less experienced users to create their own themes.
