### PR TITLE
Bittrex trading memory corruption fix

### DIFF
--- a/src/qt/tradingdialog.cpp
+++ b/src/qt/tradingdialog.cpp
@@ -926,7 +926,8 @@ QString tradingDialog::HMAC_SHA512_SIGNER(QString UrlToSign, QString Secret)
 
     // Be careful of the length of string with the choosen hash engine. SHA1 produces a 20-byte hash value which rendered as 40 characters.
     // Change the length accordingly with your choosen hash engine
-    char mdString[128];
+    // Update: and 0-terminate it!
+    char mdString[129] = { 0 };
 
     for(int i = 0; i < 64; i++){
         sprintf(&mdString[i*2], "%02x", (unsigned int)digest[i]);


### PR DESCRIPTION
Nasty bug which crashed only on OSX. 